### PR TITLE
Bump bytestring for use with ghc 9.2.1

### DIFF
--- a/bytesmith.cabal
+++ b/bytesmith.cabal
@@ -33,7 +33,7 @@ library
     Data.Bytes.Parser.Types
   build-depends:
     , base >=4.12 && <5
-    , bytestring >=0.10.8 && <0.11
+    , bytestring >=0.10.8 && <=0.11.3.0
     , byteslice >=0.1.4 && <0.3
     , contiguous >= 0.4 && < 0.7
     , primitive >=0.7 && <0.8


### PR DESCRIPTION
I am trying to use [ip](https://github.com/andrewthad/haskell-ip) with ghc 9.2.1, and bytesmith failed to solve a constraint for bytestring. I believe this is because bytestring before `0.11.1.0` requires base `<4.16`.

After bumping the version I was able to build with ghc `8.10.7` and was able to build my project with ghc `9.2.1` (where bytesmith is a transient dependency due to `ip`). I haven't tested this extensively, but this seems alright?