### PR TITLE
referencing the correct bytebuild

### DIFF
--- a/bytesmith.cabal
+++ b/bytesmith.cabal
@@ -40,6 +40,7 @@ library
     , text-short >=0.1.3 && <0.2
     , run-st >=0.1 && <0.2
     , wide-word >=0.1.0.9 && <0.2
+    , ghc-prim
   hs-source-dirs: src
   ghc-options: -O2 -Wall
   default-language: Haskell2010

--- a/bytesmith.cabal
+++ b/bytesmith.cabal
@@ -33,7 +33,7 @@ library
     Data.Bytes.Parser.Types
   build-depends:
     , base >=4.12 && <5
-    , bytestring >=0.10.8 && <=0.11.3.0
+    , bytestring >=0.10.8
     , byteslice >=0.1.4 && <0.3
     , contiguous >= 0.4 && < 0.7
     , primitive >=0.7 && <0.8

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,6 @@
-packages: .
+packages:
+    .
+    ../bytebuild
 
 package bytesmith
   ghc-options: -Wall -Werror

--- a/src/Data/Bytes/Parser.hs
+++ b/src/Data/Bytes/Parser.hs
@@ -218,11 +218,11 @@ bytes e !expected = Parser
 cstring :: e -> CString -> Parser e s ()
 cstring e (Exts.Ptr ptr0) = Parser
   ( \(# arr, off0, len0 #) s -> 
-    let go !ptr !off !len = case Exts.indexWord8OffAddr# ptr 0# of
+    let go !ptr !off !len = case Exts.indexWordOffAddr# ptr 0# of
           0## -> (# s, (# | (# (), off, len #) #) #)
           c -> case len of
             0# -> (# s, (# e | #) #)
-            _ -> case Exts.eqWord# c (Exts.indexWord8Array# arr off) of
+            _ -> case Exts.eqWord# c (Exts.indexWordArray# arr off) of
               1# -> go (Exts.plusAddr# ptr 1# ) (off +# 1# ) (len -# 1# )
               _ -> (# s, (# e | #) #)
      in go ptr0 off0 len0
@@ -483,7 +483,7 @@ unboxWord32 (Parser f) = Parser
   (\x s0 -> case f x s0 of
     (# s1, r #) -> case r of
       (# e | #) -> (# s1, (# e | #) #)
-      (# | (# W32# a, b, c #) #) -> (# s1, (# | (# a, b, c #) #) #)
+      (# | (# W32# a, b, c #) #) -> (# s1, (# | (# Exts.word32ToWord# a, b, c #) #) #)
   )
 
 -- | Convert a @(Int,Int)@ parser to a @(# Int#, Int# #)@ parser.
@@ -504,7 +504,7 @@ boxWord32 (Parser f) = Parser
   (\x s0 -> case f x s0 of
     (# s1, r #) -> case r of
       (# e | #) -> (# s1, (# e | #) #)
-      (# | (# a, b, c #) #) -> (# s1, (# | (# W32# a, b, c #) #) #)
+      (# | (# a, b, c #) #) -> (# s1, (# | (# W32# (Exts.wordToWord32# a), b, c #) #) #)
   )
 
 -- | Convert a @(# Int#, Int# #)@ parser to a @(Int,Int)@ parser.

--- a/src/Data/Bytes/Parser/Internal.hs
+++ b/src/Data/Bytes/Parser/Internal.hs
@@ -133,7 +133,7 @@ instance Applicative (Parser e s) where
 instance Monad (Parser e s) where
   {-# inline return #-}
   {-# inline (>>=) #-}
-  return = pureParser
+  return = pure
   (>>=) = bindParser
 
 instance Functor (Parser e s) where

--- a/src/Data/Bytes/Parser/Latin.hs
+++ b/src/Data/Bytes/Parser/Latin.hs
@@ -619,19 +619,19 @@ decWordStart e !chunk0 s0 = if length chunk0 > 0
 upcastWord16Result :: Result# e Word# -> Result# e Word16
 {-# inline upcastWord16Result #-}
 upcastWord16Result (# e | #) = (# e | #)
-upcastWord16Result (# | (# a, b, c #) #) = (# | (# W16# a, b, c #) #)
+upcastWord16Result (# | (# a, b, c #) #) = (# | (# W16# (Exts.wordToWord16# a), b, c #) #)
 
 -- Precondition: the word is small enough
 upcastWord32Result :: Result# e Word# -> Result# e Word32
 {-# inline upcastWord32Result #-}
 upcastWord32Result (# e | #) = (# e | #)
-upcastWord32Result (# | (# a, b, c #) #) = (# | (# W32# a, b, c #) #)
+upcastWord32Result (# | (# a, b, c #) #) = (# | (# W32# (Exts.wordToWord32# a), b, c #) #)
 
 -- Precondition: the word is small enough
 upcastWord8Result :: Result# e Word# -> Result# e Word8
 {-# inline upcastWord8Result #-}
 upcastWord8Result (# e | #) = (# e | #)
-upcastWord8Result (# | (# a, b, c #) #) = (# | (# W8# a, b, c #) #)
+upcastWord8Result (# | (# a, b, c #) #) = (# | (# W8# (Exts.wordToWord8# a), b, c #) #)
 
 -- | Parse a decimal-encoded number. If the number is too large to be
 -- represented by a machine integer, this fails with the provided
@@ -971,7 +971,7 @@ hexFixedWord32 e = Parser
   (\x s0 -> case runParser (hexFixedWord32# e) x s0 of
     (# s1, r #) -> case r of
       (# err | #) -> (# s1, (# err | #) #)
-      (# | (# a, b, c #) #) -> (# s1, (# | (# W32# a, b, c #) #) #)
+      (# | (# a, b, c #) #) -> (# s1, (# | (# W32# (Exts.wordToWord32# a), b, c #) #) #)
   )
 
 hexFixedWord32# :: e -> Parser e s Word#
@@ -1042,7 +1042,7 @@ hexFixedWord16 e = Parser
   (\x s0 -> case runParser (hexFixedWord16# e) x s0 of
     (# s1, r #) -> case r of
       (# err | #) -> (# s1, (# err | #) #)
-      (# | (# a, b, c #) #) -> (# s1, (# | (# W16# a, b, c #) #) #)
+      (# | (# a, b, c #) #) -> (# s1, (# | (# W16# (Exts.wordToWord16# a), b, c #) #) #)
   )
 
 hexFixedWord16# :: e -> Parser e s Word#
@@ -1074,7 +1074,7 @@ hexFixedWord8 e = Parser
   (\x s0 -> case runParser (hexFixedWord8# e) x s0 of
     (# s1, r #) -> case r of
       (# err | #) -> (# s1, (# err | #) #)
-      (# | (# a, b, c #) #) -> (# s1, (# | (# W8# a, b, c #) #) #)
+      (# | (# a, b, c #) #) -> (# s1, (# | (# W8# (Exts.wordToWord8# a), b, c #) #) #)
   )
 
 hexFixedWord8# :: e -> Parser e s Word#

--- a/src/Data/Bytes/Parser/Rebindable.hs
+++ b/src/Data/Bytes/Parser/Rebindable.hs
@@ -23,6 +23,7 @@ module Data.Bytes.Parser.Rebindable
 
 import Prelude () 
 import GHC.Exts (TYPE,RuntimeRep(..))
+import GHC.Types (LiftedRep)
 import Data.Bytes.Parser.Internal (Parser(..))
 
 class Bind (ra :: RuntimeRep) (rb :: RuntimeRep) where
@@ -187,25 +188,25 @@ sequenceInt2to5Parser (Parser f) (Parser g) = Parser
       (# | (# _, b, c #) #) -> g (# arr, b, c #) s1
   )
 
-instance Bind 'LiftedRep 'LiftedRep where
+instance Bind LiftedRep LiftedRep where
   {-# inline (>>=) #-}
   {-# inline (>>) #-}
   (>>=) = bindParser
   (>>) = sequenceParser
 
-instance Bind 'WordRep 'LiftedRep where
+instance Bind 'WordRep LiftedRep where
   {-# inline (>>=) #-}
   {-# inline (>>) #-}
   (>>=) = bindWordParser
   (>>) = sequenceWordParser
 
-instance Bind 'IntRep 'LiftedRep where
+instance Bind 'IntRep LiftedRep where
   {-# inline (>>=) #-}
   {-# inline (>>) #-}
   (>>=) = bindIntParser
   (>>) = sequenceIntParser
 
-instance Bind ('TupleRep '[ 'IntRep, 'IntRep]) 'LiftedRep where
+instance Bind ('TupleRep '[ 'IntRep, 'IntRep]) LiftedRep where
   {-# inline (>>=) #-}
   {-# inline (>>) #-}
   (>>=) = bindIntPairParser
@@ -221,7 +222,7 @@ instance Bind ('TupleRep '[ 'IntRep, 'IntRep])
   (>>) = sequenceInt2to5Parser
 
 instance Bind ('TupleRep '[ 'IntRep, 'IntRep, 'IntRep, 'IntRep, 'IntRep]) 
-              'LiftedRep
+              LiftedRep
   where
   {-# inline (>>=) #-}
   {-# inline (>>) #-}
@@ -237,13 +238,13 @@ instance Bind 'IntRep
   (>>=) = bindFromIntToInt5
   (>>) = sequenceIntToInt5
 
-instance Bind 'LiftedRep ('TupleRep '[ 'IntRep, 'IntRep]) where
+instance Bind LiftedRep ('TupleRep '[ 'IntRep, 'IntRep]) where
   {-# inline (>>=) #-}
   {-# inline (>>) #-}
   (>>=) = bindFromLiftedToIntPair
   (>>) = sequenceLiftedToIntPair
 
-instance Bind 'LiftedRep
+instance Bind LiftedRep
               ('TupleRep '[ 'IntRep, 'IntRep, 'IntRep, 'IntRep, 'IntRep]) 
   where
   {-# inline (>>=) #-}
@@ -257,13 +258,13 @@ instance Bind 'IntRep ('TupleRep '[ 'IntRep, 'IntRep]) where
   (>>=) = bindFromIntToIntPair
   (>>) = sequenceIntToIntPair
 
-instance Bind 'LiftedRep 'IntRep where
+instance Bind LiftedRep 'IntRep where
   {-# inline (>>=) #-}
   {-# inline (>>) #-}
   (>>=) = bindFromLiftedToInt
   (>>) = sequenceLiftedToInt
 
-instance Pure 'LiftedRep where
+instance Pure LiftedRep where
   {-# inline pure #-}
   pure = pureParser
 
@@ -343,7 +344,7 @@ sequenceIntToInt5 (Parser f) (Parser g) = Parser
 
 bindFromLiftedToIntPair ::
      forall s e
-       (a :: TYPE 'LiftedRep)
+       (a :: TYPE LiftedRep)
        (b :: TYPE ('TupleRep '[ 'IntRep, 'IntRep ])).
      Parser s e a
   -> (a -> Parser s e b)
@@ -359,7 +360,7 @@ bindFromLiftedToIntPair (Parser f) g = Parser
 
 sequenceLiftedToIntPair ::
      forall s e
-       (a :: TYPE 'LiftedRep)
+       (a :: TYPE LiftedRep)
        (b :: TYPE ('TupleRep '[ 'IntRep, 'IntRep ])).
      Parser s e a
   -> Parser s e b
@@ -375,7 +376,7 @@ sequenceLiftedToIntPair (Parser f) (Parser g) = Parser
 
 bindFromLiftedToInt5 ::
      forall s e
-       (a :: TYPE 'LiftedRep)
+       (a :: TYPE LiftedRep)
        (b :: TYPE ('TupleRep '[ 'IntRep, 'IntRep, 'IntRep, 'IntRep, 'IntRep])).
      Parser s e a
   -> (a -> Parser s e b)
@@ -391,7 +392,7 @@ bindFromLiftedToInt5 (Parser f) g = Parser
 
 sequenceLiftedToInt5 ::
      forall s e
-       (a :: TYPE 'LiftedRep)
+       (a :: TYPE LiftedRep)
        (b :: TYPE ('TupleRep '[ 'IntRep, 'IntRep, 'IntRep, 'IntRep, 'IntRep ])).
      Parser s e a
   -> Parser s e b
@@ -406,7 +407,7 @@ sequenceLiftedToInt5 (Parser f) (Parser g) = Parser
 
 bindFromLiftedToInt ::
      forall s e
-       (a :: TYPE 'LiftedRep)
+       (a :: TYPE LiftedRep)
        (b :: TYPE 'IntRep).
      Parser s e a
   -> (a -> Parser s e b)
@@ -422,7 +423,7 @@ bindFromLiftedToInt (Parser f) g = Parser
 
 sequenceLiftedToInt ::
      forall s e
-       (a :: TYPE 'LiftedRep)
+       (a :: TYPE LiftedRep)
        (b :: TYPE 'IntRep).
      Parser s e a
   -> Parser s e b

--- a/src/Data/Bytes/Parser/Utf8.hs
+++ b/src/Data/Bytes/Parser/Utf8.hs
@@ -47,7 +47,7 @@ any# e = Parser
     1# ->
       let !w0 = Exts.indexWord8Array# arr off
        in if | oneByteChar (W8# w0) -> 
-                 (# s0, (# | (# chr# (Exts.word2Int# w0), off +# 1#, len -# 1# #) #) #)
+                 (# s0, (# | (# chr# (Exts.word2Int# (Exts.word8ToWord# w0)), off +# 1#, len -# 1# #) #) #)
              | twoByteChar (W8# w0) ->
                  if | I# len > 1
                     , w1 <- Exts.indexWord8Array# arr (off +# 1#)


### PR DESCRIPTION
I have been trying to adapt this library for ghc9.2 but I am blocked against some errors:

```
Build profile: -w ghc-9.2.1 -O1
In order, the following will be built (use -v for more details):
 - bytesmith-0.3.8.0 (lib) (first run)
Preprocessing library for bytesmith-0.3.8.0..
Building library for bytesmith-0.3.8.0..
[ 5 of 12] Compiling Data.Bytes.Parser ( src/Data/Bytes/Parser.hs, /home/teto/mptcp/bytesmith/dist-newstyle/build/x86_64-linux/ghc-9.2.1/bytesmith-0.3.8.0/build/Data/Bytes/Parser.o, /home/teto/mptcp/bytesmith/dist-newstyle/build/x86_64-linux/ghc-9.2.1/bytesmith-0.3.8.0/build/Data/Bytes/Parser.dyn_o )

src/Data/Bytes/Parser.hs:222:11: error:
    • Couldn't match expected type ‘Exts.Word8#’
                  with actual type ‘Word#’
    • In the pattern: 0##
      In a case alternative: 0## -> (# s, (# | (# (), off, len #) #) #)
      In the expression:
        case Exts.indexWord8OffAddr# ptr 0# of
          0## -> (# s, (# | (# (), off, len #) #) #)
          c -> case len of
                 0# -> (# s, (# e | #) #)
                 _ -> case Exts.eqWord# c (Exts.indexWord8Array# arr off) of
                        1# -> ...
                        _ -> ...
    |
222 |           0## -> (# s, (# | (# (), off, len #) #) #)
    |           ^^^

src/Data/Bytes/Parser.hs:225:36: error:
    • Couldn't match expected type ‘Word#’
                  with actual type ‘Exts.Word8#’
    • In the first argument of ‘Exts.eqWord#’, namely ‘c’
      In the expression: Exts.eqWord# c (Exts.indexWord8Array# arr off)
      In the expression:
        case Exts.eqWord# c (Exts.indexWord8Array# arr off) of
          1# -> go (Exts.plusAddr# ptr 1#) (off +# 1#) (len -# 1#)
          _ -> (# s, (# e | #) #)
    |
225 |             _ -> case Exts.eqWord# c (Exts.indexWord8Array# arr off) of
    |                                    ^

src/Data/Bytes/Parser.hs:225:39: error:
    • Couldn't match expected type ‘Word#’
                  with actual type ‘Exts.Word8#’
    • In the second argument of ‘Exts.eqWord#’, namely
        ‘(Exts.indexWord8Array# arr off)’
      In the expression: Exts.eqWord# c (Exts.indexWord8Array# arr off)
      In the expression:
        case Exts.eqWord# c (Exts.indexWord8Array# arr off) of
          1# -> go (Exts.plusAddr# ptr 1#) (off +# 1#) (len -# 1#)
          _ -> (# s, (# e | #) #)
    |
225 |             _ -> case Exts.eqWord# c (Exts.indexWord8Array# arr off) of
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/Bytes/Parser.hs:486:52: error:
    • Couldn't match expected type ‘Word#’
                  with actual type ‘Exts.Word32#’
    • In the expression: a
      In the expression: (# a, b, c #)
      In the expression: (# | (# a, b, c #) #)
    |
486 |       (# | (# W32# a, b, c #) #) -> (# s1, (# | (# a, b, c #) #) #)
    |                                                    ^

src/Data/Bytes/Parser.hs:507:52: error:
    • Couldn't match expected type ‘Exts.Word32#’
                  with actual type ‘Word#’
    • In the first argument of ‘W32#’, namely ‘a’
      In the expression: W32# a
      In the expression: (# W32# a, b, c #)
    |
507 |       (# | (# a, b, c #) #) -> (# s1, (# | (# W32# a, b, c #) #) #)
    |                                                    ^
    ```