### PR TITLE
Bump `bytestring` Upper Bound to 0.11.4.0

### DIFF
--- a/bytesmith.cabal
+++ b/bytesmith.cabal
@@ -33,7 +33,7 @@ library
     Data.Bytes.Parser.Types
   build-depends:
     , base >=4.12 && <5
-    , bytestring >=0.10.8 && <=0.11.3.0
+    , bytestring >=0.10.8 && <=0.11.4.0
     , byteslice >=0.2.6 && <0.3
     , contiguous >= 0.6 && < 0.7
     , primitive >=0.7 && <0.8


### PR DESCRIPTION
This is needed to compile against Stackage Nightly. Can we have a cabal metadata revision change with the updated upper bound as well?

Tested with:
```sh
$ stack build --fast --test -j$(nproc) --haddock --bench --no-run-benchmarks --resolver nightly
...
All 72 tests passed (0.04s)
```