### PR TITLE
fix `satisfy` parser

### DIFF
--- a/src/Data/Bytes/Parser.hs
+++ b/src/Data/Bytes/Parser.hs
@@ -457,8 +457,8 @@ satisfy e p = satisfyWith e id p
 --   The parser returns the transformed byte that was parsed.
 satisfyWith :: e -> (Word8 -> a) -> (a -> Bool) -> Parser e s a
 {-# inline satisfyWith #-}
-satisfyWith e f p = uneffectful $ \chunk -> if length chunk > 1
-  then case B.unsafeIndex chunk 1 of
+satisfyWith e f p = uneffectful $ \chunk -> if length chunk > 0
+  then case B.unsafeIndex chunk 0 of
     w ->
       let v = f w
       in if p v

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -436,6 +436,12 @@ tests = testGroup "Parser"
         ===
         Just w
     ]
+  , testGroup "satisfy"
+    [ testCase "A" $
+        P.Success (Slice 2 0 0x20)
+        @=?
+        P.parseBytes (P.satisfy () (== 0x20)) (bytes "\x20")
+    ]
   ]
 
 bytes :: String -> Bytes


### PR DESCRIPTION
Hey! This PR (I believe) fixes the `satisfy` combinator, unless I misunderstand how it's supposed to work. Thanks.