### PR TITLE
build with primitive 0.8

### DIFF
--- a/bytesmith.cabal
+++ b/bytesmith.cabal
@@ -37,7 +37,7 @@ library
     , bytestring >=0.10.8 && <=0.12
     , byteslice >=0.2.6 && <0.3
     , contiguous >= 0.6 && < 0.7
-    , primitive >=0.7 && <0.8
+    , primitive >=0.7 && <0.9
     , text-short >=0.1.3 && <0.2
     , run-st >=0.1 && <0.2
     , wide-word >=0.1.0.9 && <0.2


### PR DESCRIPTION
```
❯ cabal build --constraint="primitive == 0.8.0.0" --allow-newer=byteslice:primitive --allow-newer=run-st:primitive --allow-newer=wide-word:primitive --allow-newer=primitive-unlifted:primitive --allow-newer=contiguous:primitive --allow-newer=tuples:primitive --allow-newer=primitive-addr:primitive
Resolving dependencies...
Build profile: -w ghc-9.4.4 -O1
In order, the following will be built (use -v for more details):
 - contiguous-0.6.3.0 (lib) (requires build)
 - bytesmith-0.3.10.0 (lib) (first run)
Starting     contiguous-0.6.3.0 (lib)
Building     contiguous-0.6.3.0 (lib)
Installing   contiguous-0.6.3.0 (lib)
Completed    contiguous-0.6.3.0 (lib)
Configuring library for bytesmith-0.3.10.0..
Preprocessing library for bytesmith-0.3.10.0..
Building library for bytesmith-0.3.10.0..
[ 1 of 12] Compiling Data.Bytes.Parser.Internal ( src/Data/Bytes/Parser/Internal.hs, /home/chessai/haskell/bytesmith/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytesmith-0.3.10.0/build/Data/Bytes/Parser/Internal.o, /home/chessai/haskell/bytesmith/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytesmith-0.3.10.0/build/Data/Bytes/Parser/Internal.dyn_o )
[ 2 of 12] Compiling Data.Bytes.Parser.Rebindable ( src/Data/Bytes/Parser/Rebindable.hs, /home/chessai/haskell/bytesmith/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytesmith-0.3.10.0/build/Data/Bytes/Parser/Rebindable.o, /home/chessai/haskell/bytesmith/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytesmith-0.3.10.0/build/Data/Bytes/Parser/Rebindable.dyn_o )
[ 3 of 12] Compiling Data.Bytes.Parser.Types ( src/Data/Bytes/Parser/Types.hs, /home/chessai/haskell/bytesmith/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytesmith-0.3.10.0/build/Data/Bytes/Parser/Types.o, /home/chessai/haskell/bytesmith/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytesmith-0.3.10.0/build/Data/Bytes/Parser/Types.dyn_o )
[ 4 of 12] Compiling Data.Bytes.Parser.Unsafe ( src/Data/Bytes/Parser/Unsafe.hs, /home/chessai/haskell/bytesmith/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytesmith-0.3.10.0/build/Data/Bytes/Parser/Unsafe.o, /home/chessai/haskell/bytesmith/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytesmith-0.3.10.0/build/Data/Bytes/Parser/Unsafe.dyn_o )
[ 5 of 12] Compiling Data.Bytes.Parser ( src/Data/Bytes/Parser.hs, /home/chessai/haskell/bytesmith/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytesmith-0.3.10.0/build/Data/Bytes/Parser.o, /home/chessai/haskell/bytesmith/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytesmith-0.3.10.0/build/Data/Bytes/Parser.dyn_o )
[ 6 of 12] Compiling Data.Bytes.Parser.LittleEndian ( src/Data/Bytes/Parser/LittleEndian.hs, /home/chessai/haskell/bytesmith/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytesmith-0.3.10.0/build/Data/Bytes/Parser/LittleEndian.o, /home/chessai/haskell/bytesmith/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytesmith-0.3.10.0/build/Data/Bytes/Parser/LittleEndian.dyn_o )
[ 7 of 12] Compiling Data.Bytes.Parser.Leb128 ( src/Data/Bytes/Parser/Leb128.hs, /home/chessai/haskell/bytesmith/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytesmith-0.3.10.0/build/Data/Bytes/Parser/Leb128.o, /home/chessai/haskell/bytesmith/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytesmith-0.3.10.0/build/Data/Bytes/Parser/Leb128.dyn_o )
[ 8 of 12] Compiling Data.Bytes.Parser.Latin ( src/Data/Bytes/Parser/Latin.hs, /home/chessai/haskell/bytesmith/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytesmith-0.3.10.0/build/Data/Bytes/Parser/Latin.o, /home/chessai/haskell/bytesmith/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytesmith-0.3.10.0/build/Data/Bytes/Parser/Latin.dyn_o )
[ 9 of 12] Compiling Data.Bytes.Parser.Ascii ( src/Data/Bytes/Parser/Ascii.hs, /home/chessai/haskell/bytesmith/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytesmith-0.3.10.0/build/Data/Bytes/Parser/Ascii.o, /home/chessai/haskell/bytesmith/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytesmith-0.3.10.0/build/Data/Bytes/Parser/Ascii.dyn_o )
[10 of 12] Compiling Data.Bytes.Parser.BigEndian ( src/Data/Bytes/Parser/BigEndian.hs, /home/chessai/haskell/bytesmith/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytesmith-0.3.10.0/build/Data/Bytes/Parser/BigEndian.o, /home/chessai/haskell/bytesmith/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytesmith-0.3.10.0/build/Data/Bytes/Parser/BigEndian.dyn_o )
[11 of 12] Compiling Data.Bytes.Parser.Base128 ( src/Data/Bytes/Parser/Base128.hs, /home/chessai/haskell/bytesmith/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytesmith-0.3.10.0/build/Data/Bytes/Parser/Base128.o, /home/chessai/haskell/bytesmith/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytesmith-0.3.10.0/build/Data/Bytes/Parser/Base128.dyn_o )
[12 of 12] Compiling Data.Bytes.Parser.Utf8 ( src/Data/Bytes/Parser/Utf8.hs, /home/chessai/haskell/bytesmith/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytesmith-0.3.10.0/build/Data/Bytes/Parser/Utf8.o, /home/chessai/haskell/bytesmith/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytesmith-0.3.10.0/build/Data/Bytes/Parser/Utf8.dyn_o )
```