### PR TITLE
Slightly update bound for `bytestring`

### DIFF
--- a/bytesmith.cabal
+++ b/bytesmith.cabal
@@ -35,7 +35,7 @@ library
   build-depends:
     , base >=4.12 && <5
     , byteslice >=0.2.6 && <0.3
-    , bytestring >=0.10.8 && <=0.12
+    , bytestring >=0.10.8 && <0.13
     , contiguous >= 0.6 && < 0.7
     , natural-arithmetic >=0.1.3
     , primitive >=0.7 && <0.10


### PR DESCRIPTION
To allow not only bytestring-0.12.0.0, but also bytestring-0.12.0.2.