### PR TITLE
Remove dependency on run-st library

### DIFF
--- a/bytesmith.cabal
+++ b/bytesmith.cabal
@@ -47,7 +47,6 @@ library
     , contiguous          >=0.6     && <0.7
     , natural-arithmetic  >=0.1.3
     , primitive           >=0.7     && <0.10
-    , run-st              >=0.1     && <0.2
     , text-short          >=0.1.3   && <0.2
     , wide-word           >=0.1.0.9 && <0.2
 

--- a/sample/TakeLetter.hs
+++ b/sample/TakeLetter.hs
@@ -1,0 +1,17 @@
+{-# language MagicHash #-}
+
+-- Build with:
+--   ghc -fforce-recomp -O2 -ddump-simpl -dsuppress-all -ddump-to-file sample/TakeLetter.hs
+-- to examine GHC optimizations.
+module TakeLetter
+  ( takeLetter
+  ) where
+
+import Data.Bytes.Parser (Parser)
+import Data.Text.Short (ShortText)
+import Data.Bytes.Parser.Ascii (takeShortWhile)
+import GHC.Exts
+
+takeLetter :: Parser e s ShortText
+{-# noinline takeLetter #-}
+takeLetter = takeShortWhile (== 'A')

--- a/src/Data/Bytes/Parser/Ascii.hs
+++ b/src/Data/Bytes/Parser/Ascii.hs
@@ -54,7 +54,7 @@ module Data.Bytes.Parser.Ascii
 
 import Prelude hiding (any, fail, length, takeWhile)
 
-import Control.Monad.ST.Run (runByteArrayST)
+import Control.Monad.ST (runST)
 import Data.Bits (clearBit)
 import Data.Bytes.Parser.Internal (Parser (..), Result (..), Result#, indexLatinCharArray, uneffectful, uneffectful#, upcastUnitSuccess)
 import Data.Bytes.Types (Bytes (..))
@@ -115,7 +115,7 @@ takeShortWhile p = do
   end <- Unsafe.cursor
   src <- Unsafe.expose
   let len = end - start
-      !r = runByteArrayST $ do
+      !r = runST $ do
         marr <- PM.newByteArray len
         PM.copyByteArray marr 0 src start len
         PM.unsafeFreezeByteArray marr
@@ -136,7 +136,7 @@ shortTrailedBy e !c = do
   end <- Unsafe.cursor
   src <- Unsafe.expose
   let len = end - start - 1
-      !r = runByteArrayST $ do
+      !r = runST $ do
         marr <- PM.newByteArray len
         PM.copyByteArray marr 0 src start len
         PM.unsafeFreezeByteArray marr

--- a/src/Data/Bytes/Parser/Internal.hs
+++ b/src/Data/Bytes/Parser/Internal.hs
@@ -38,7 +38,7 @@ module Data.Bytes.Parser.Internal
 import Prelude hiding (any, fail, length, takeWhile)
 
 import Control.Applicative (Alternative)
-import Control.Monad.ST.Run (runByteArrayST)
+import Control.Monad.ST (runST)
 import Data.Bytes.Types (Bytes (..))
 import Data.Kind (Type)
 import Data.Primitive (ByteArray (ByteArray))
@@ -169,7 +169,7 @@ upcastUnitSuccess :: (# Int#, Int# #) -> Result# e ()
 upcastUnitSuccess (# b, c #) = (# | (# (), b, c #) #)
 
 swapArray16 :: Bytes -> ByteArray
-swapArray16 (Bytes {array, offset, length}) = runByteArrayST $ do
+swapArray16 (Bytes {array, offset, length}) = runST $ do
   dst <- PM.newByteArray length
   let go !ixSrc !ixDst !len =
         if len > 0
@@ -184,7 +184,7 @@ swapArray16 (Bytes {array, offset, length}) = runByteArrayST $ do
   PM.unsafeFreezeByteArray dst
 
 swapArray32 :: Bytes -> ByteArray
-swapArray32 (Bytes {array, offset, length}) = runByteArrayST $ do
+swapArray32 (Bytes {array, offset, length}) = runST $ do
   dst <- PM.newByteArray length
   let go !ixSrc !ixDst !len =
         if len > 0
@@ -203,7 +203,7 @@ swapArray32 (Bytes {array, offset, length}) = runByteArrayST $ do
   PM.unsafeFreezeByteArray dst
 
 swapArray64 :: Bytes -> ByteArray
-swapArray64 (Bytes {array, offset, length}) = runByteArrayST $ do
+swapArray64 (Bytes {array, offset, length}) = runST $ do
   dst <- PM.newByteArray length
   let go !ixSrc !ixDst !len =
         if len > 0
@@ -230,7 +230,7 @@ swapArray64 (Bytes {array, offset, length}) = runByteArrayST $ do
   PM.unsafeFreezeByteArray dst
 
 swapArray128 :: Bytes -> ByteArray
-swapArray128 (Bytes {array, offset, length}) = runByteArrayST $ do
+swapArray128 (Bytes {array, offset, length}) = runST $ do
   dst <- PM.newByteArray length
   let go !ixSrc !ixDst !len =
         if len > 0
@@ -273,7 +273,7 @@ swapArray128 (Bytes {array, offset, length}) = runByteArrayST $ do
   PM.unsafeFreezeByteArray dst
 
 swapArray256 :: Bytes -> ByteArray
-swapArray256 (Bytes {array, offset, length}) = runByteArrayST $ do
+swapArray256 (Bytes {array, offset, length}) = runST $ do
   dst <- PM.newByteArray length
   let go !ixSrc !ixDst !len =
         if len > 0


### PR DESCRIPTION
A simple test has been added at sample/TakeLetter.hs. This demonstrates that there is no regression to the GHC Core from replacing runByteArrayST with runST.